### PR TITLE
Fix encoded spaces in screenshot name [iOS]

### DIFF
--- a/lib/src/image_processor.dart
+++ b/lib/src/image_processor.dart
@@ -81,6 +81,9 @@ class ImageProcessor {
             await frame(_config.stagingDir, screenProps, screenshotPath.path,
                 deviceType, runMode);
           }
+          if (screenshotPath.path.contains('%')) {
+            await utils.fixEncodedChars(screenshotPath.path);
+          }
         }
         status.stop();
       } else {

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -31,6 +31,14 @@ void moveFiles(String srcDir, String dstDir) {
   });
 }
 
+/// Fixes URL escaped characters in [filePath].
+Future<void> fixEncodedChars(String filePath) async {
+  if (!fs.isFileSync(filePath)) {
+    return;
+  }
+  await fs.file(filePath).rename(Uri.decodeComponent(filePath));
+}
+
 /// Creates a list of available iOS simulators.
 /// (really just concerned with simulators for now).
 /// Provides access to their IDs and status'.


### PR DESCRIPTION
Detect and fix if the screenshot file name contains encoded characters. 
This was happening when capturing screenshots with blank spaces in the name under ios.