### PR TITLE
Fixing ios crash happening when changing devices and languages.

### DIFF
--- a/lib/src/run.dart
+++ b/lib/src/run.dart
@@ -399,8 +399,10 @@ class Screenshots {
         // if a simulator was started, revert locale if necessary and shut it down
         if (simulator != null) {
           // todo restore backup of GlobalPreferences.plist
-          await setSimulatorLocale(deviceId, configDeviceName, origIosLocale!,
-              config.stagingDir, daemonClient);
+          if (origIosLocale != null) {
+            await setSimulatorLocale(deviceId, configDeviceName, origIosLocale!,
+                config.stagingDir, daemonClient);
+          }
           await shutdownSimulator(deviceId);
         }
       }


### PR DESCRIPTION
Checking if original locale is set or not before reverting device locale.